### PR TITLE
fix(liveness): normalize yaw sign, single authority for head phases; …

### DIFF
--- a/src/features/scan-face/components/VideoCanvas.tsx
+++ b/src/features/scan-face/components/VideoCanvas.tsx
@@ -14,7 +14,17 @@ import {
   drawLandmarks,
 } from "../utils/canvasDraw";
 
-const SHOW_OVERLAY = false; // true = วาดกรอบ, ข้อความ, landmarks
+const SHOW_OVERLAY = true; // true = วาดกรอบ, ข้อความ, landmarks
+
+/** 👻 ทำให้ overlay วาดจริงแต่โปร่งใส (ยังคงคำนวณ/เรียกฟังก์ชันวาดครบ) */
+const OVERLAY_VISUAL_ALPHA = 0; // 0 = มองไม่เห็น, 1 = ปกติ
+function withOverlayAlpha(ctx: CanvasRenderingContext2D, draw: () => void) {
+  if (!SHOW_OVERLAY) return;
+  ctx.save();
+  ctx.globalAlpha *= OVERLAY_VISUAL_ALPHA;
+  draw();
+  ctx.restore();
+}
 
 /** ====== ค่าจาก CONFIG สำหรับ Landmarks ====== */
 const LM_CFG = (CONFIG as any).LANDMARKS ?? {};
@@ -100,19 +110,19 @@ export function VideoCanvas({
     ctx.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
     ctx.restore();
 
-    // 2) Overlay
+    // 2) Overlay per step (ยังคงคำนวณ/เรียกฟังก์ชันวาด แต่ทำให้โปร่งใส)
     if (state.step === 1) {
       drawStep1(ctx, detectionResults, canvas.width, canvas.height);
     } else if (state.step === 2) {
       drawStep2(ctx, detectionResults[0], state, canvas.width, canvas.height);
     } else if (state.step === 3) {
-      if (SHOW_OVERLAY) {
+      withOverlayAlpha(ctx, () => {
         banner(ctx, " ", 60);
-      }
+      });
     }
 
-    // 3) วาด crosshair กลางจอ (บนสุด)
-    if (SHOW_OVERLAY) {
+    // 3) crosshair กลางจอ (บนสุด)
+    withOverlayAlpha(ctx, () => {
       drawCrosshair(
         ctx,
         canvas.width / 2,
@@ -121,7 +131,7 @@ export function VideoCanvas({
         2,
         "#22c55e"
       );
-    }
+    });
   }, [state, detectionResults, videoElement, canvasRef]);
 
   return (
@@ -147,7 +157,8 @@ function drawStep1(
     canvasHeight
   );
 
-  if (SHOW_OVERLAY) {
+  // วาดกรอบ/ข้อความ/landmarks แบบโปร่งใส (ยังคงเรียกฟังก์ชันวาดครบ)
+  withOverlayAlpha(ctx, () => {
     alertFrame(
       ctx,
       validation.isValid ? "rgba(255,255,255,1)" : "rgba(255,0,0,1)",
@@ -163,11 +174,12 @@ function drawStep1(
 
     if (LM_SHOW_STEP1) {
       detectionResults.forEach((d) => {
-        if (!d.landmarks) return;
+        const lms = d.landmarks; // LM[] | null
+        if (!lms) return;        // แคบชนิดให้เป็น LM[]
         if (LM_MODE === "nose") {
-          drawNoseLandmarks(ctx, d.landmarks, canvasWidth, canvasHeight);
+          drawNoseLandmarks(ctx, lms, canvasWidth, canvasHeight);
         } else {
-          // drawLandmarks(ctx, d.landmarks as any, LM_RADIUS, LM_COLOR);
+          drawLandmarks(ctx, lms as any, LM_RADIUS, LM_COLOR);
         }
       });
     }
@@ -175,8 +187,9 @@ function drawStep1(
     if (validation.message) {
       banner(ctx, validation.message, 80);
     }
-  }
+  });
 
+  // NOTE: sharpen/PiP ปล่อยวาดปกติ (ไม่ใช่กรอบ/ข้อความ/landmarks)
   if (CONFIG.SHARPEN.ENABLED) {
     const pipW = 160,
       pipH = 120;
@@ -196,23 +209,31 @@ function drawStep2(
   canvasWidth: number,
   canvasHeight: number
 ) {
-  if (!detection?.landmarks || state.phase === "-") return;
+  if (!detection || state.phase === "-") return;
 
-  if (SHOW_OVERLAY && LM_SHOW_STEP2) {
-    if (LM_MODE === "nose") {
-      drawNoseLandmarks(ctx, detection.landmarks, canvasWidth, canvasHeight);
-    } else {
-      drawLandmarks(ctx, detection.landmarks as any, LM_RADIUS, LM_COLOR);
+  const lms = detection.landmarks; // LM[] | null
+  if (!lms) return;                // แคบชนิดให้เป็น LM[] ต่อจากนี้
+
+  // Landmarks (โปร่งใส)
+  withOverlayAlpha(ctx, () => {
+    if (LM_SHOW_STEP2) {
+      if (LM_MODE === "nose") {
+        drawNoseLandmarks(ctx, lms, canvasWidth, canvasHeight);
+      } else {
+        drawLandmarks(ctx, lms as any, LM_RADIUS, LM_COLOR);
+      }
     }
-  }
+  });
 
+  // ข้อความคำสั่งของเฟส (โปร่งใส)
   const instruction = Step2Validator.getPhaseInstruction(state.phase as any);
-  banner(ctx, instruction, 120);
+  withOverlayAlpha(ctx, () => {
+    banner(ctx, instruction, 120);
+  });
 
-  // แสดง metric พื้นฐานเพื่อดีบัก
+  // คำนวณ metric ต่อ (ไม่เกี่ยวกับการแสดงผล)
   const noseIdx = 1;
-  const lm = detection.landmarks as LM[];
-  const nose = lm?.[noseIdx];
+  const nose = lms[noseIdx];
   if (nose) {
     let xPx = nose.x * canvasWidth;
     const yPx = nose.y * canvasHeight;
@@ -222,8 +243,9 @@ function drawStep2(
     const dx = xPx - cx;
     const dy = yPx - cy;
 
-    ctx.save();
-    if (SHOW_OVERLAY) {
+    // debug text + กรอบ status (โปร่งใส)
+    withOverlayAlpha(ctx, () => {
+      ctx.save();
       ctx.fillStyle = "white";
       ctx.font = "16px system-ui";
       const lines = [
@@ -231,14 +253,16 @@ function drawStep2(
         `dx: ${dx.toFixed(1)} px, dy: ${dy.toFixed(1)} px`,
       ];
       lines.forEach((t, i) => ctx.fillText(t, 10, 56 + i * 18));
-    }
-    ctx.restore();
+      ctx.restore();
 
-    // กรอบสีบอกสถานะคร่าว ๆ (เฉพาะแสดงผล)
-    alertFrame(ctx, "rgba(255,255,255,0.6)", 4);
+      alertFrame(ctx, "rgba(255,255,255,0.6)", 4);
+    });
   }
 
+  // mouth phase banner (โปร่งใส)
   if (state.phase === "mouth" && detection.marValue !== null) {
-    banner(ctx, "Now, please close your mouth", 150);
+    withOverlayAlpha(ctx, () => {
+      banner(ctx, "Now, please close your mouth", 150);
+    });
   }
 }

--- a/src/features/scan-face/components/VideoCanvas.tsx
+++ b/src/features/scan-face/components/VideoCanvas.tsx
@@ -1,7 +1,8 @@
+// components/VideoCanvas.tsx
 "use client";
 
 import React, { useEffect } from "react";
-import { DetectionResult, FaceScanState } from "../configs/type";
+import type { DetectionResult, FaceScanState, LM } from "../configs/type";
 import { CONFIG } from "../configs/constant";
 import { Step1Validator } from "../utils/validators/step1Validator";
 import { Step2Validator } from "../utils/validators/step2Validator";
@@ -13,8 +14,62 @@ import {
   drawLandmarks,
 } from "../utils/canvasDraw";
 
-// ตั้งค่าใน .env.local ตอน dev: NEXT_PUBLIC_SHOW_OVERLAY=1
-const SHOW_OVERLAY = process.env.NEXT_PUBLIC_SHOW_OVERLAY === "1";
+const SHOW_OVERLAY = false; // true = วาดกรอบ, ข้อความ, landmarks
+
+/** ====== ค่าจาก CONFIG สำหรับ Landmarks ====== */
+const LM_CFG = (CONFIG as any).LANDMARKS ?? {};
+const LM_MODE: "nose" | "all" = (LM_CFG.MODE as any) ?? "nose";
+const LM_SHOW_STEP1: boolean = LM_CFG.SHOW_IN_STEP1 ?? true;
+const LM_SHOW_STEP2: boolean = LM_CFG.SHOW_IN_STEP2 ?? true;
+const LM_COLOR: string = LM_CFG.COLOR ?? "#00ff00";
+const LM_RADIUS: number = LM_CFG.RADIUS ?? 3;
+
+/** เครื่องหมายบวกกลางจอ (วาดหลัง restore เพื่อไม่โดน mirror) */
+function drawCrosshair(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size = 14,
+  lineWidth = 3,
+  color = "#22c55e"
+) {
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = lineWidth;
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  ctx.moveTo(x - size, y);
+  ctx.lineTo(x + size, y);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(x, y - size);
+  ctx.lineTo(x, y + size);
+  ctx.stroke();
+  ctx.restore();
+}
+
+/** ดัชนีจมูก */
+const NOSE_LANDMARKS = [1, 2, 97, 326, 6, 197];
+
+function drawNoseLandmarks(
+  ctx: CanvasRenderingContext2D,
+  landmarks: LM[],
+  canvasWidth: number,
+  canvasHeight: number,
+  radius = LM_RADIUS,
+  color = LM_COLOR
+) {
+  ctx.save();
+  ctx.fillStyle = color;
+  for (const idx of NOSE_LANDMARKS) {
+    const pt = landmarks[idx];
+    if (!pt) continue;
+    ctx.beginPath();
+    ctx.arc(pt.x * canvasWidth, pt.y * canvasHeight, radius, 0, 2 * Math.PI);
+    ctx.fill();
+  }
+  ctx.restore();
+}
 
 interface VideoCanvasProps {
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
@@ -34,7 +89,8 @@ export function VideoCanvas({
 
     const canvas = canvasRef.current;
     const ctx = canvas.getContext("2d")!;
-    // ล้างแล้ววาดวิดีโอ
+
+    // 1) วาดภาพจากวิดีโอ (ตามการ mirror ที่ตั้งไว้)
     ctx.save();
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     if (CONFIG.CAMERA.MIRRORED_INPUT) {
@@ -44,17 +100,29 @@ export function VideoCanvas({
     ctx.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
     ctx.restore();
 
-    // วาดตามขั้นตอน
+    // 2) Overlay
     if (state.step === 1) {
       drawStep1(ctx, detectionResults, canvas.width, canvas.height);
     } else if (state.step === 2) {
-      drawStep2(ctx, detectionResults[0], state);
+      drawStep2(ctx, detectionResults[0], state, canvas.width, canvas.height);
     } else if (state.step === 3) {
       if (SHOW_OVERLAY) {
         banner(ctx, " ", 60);
       }
     }
-  }, [state, detectionResults, videoElement]);
+
+    // 3) วาด crosshair กลางจอ (บนสุด)
+    if (SHOW_OVERLAY) {
+      drawCrosshair(
+        ctx,
+        canvas.width / 2,
+        canvas.height / 2 + canvas.height * 0.1, // ➜ เลื่อนลง 10% ของความสูง
+        14,
+        2,
+        "#22c55e"
+      );
+    }
+  }, [state, detectionResults, videoElement, canvasRef]);
 
   return (
     <canvas
@@ -66,14 +134,13 @@ export function VideoCanvas({
   );
 }
 
+/* ====== Step 1 UI ====== */
 function drawStep1(
   ctx: CanvasRenderingContext2D,
   detectionResults: DetectionResult[],
   canvasWidth: number,
   canvasHeight: number
 ) {
-  const faceCount = detectionResults.length;
-
   const validation = Step1Validator.validateStep1(
     detectionResults,
     canvasWidth,
@@ -86,6 +153,7 @@ function drawStep1(
       validation.isValid ? "rgba(255,255,255,1)" : "rgba(255,0,0,1)",
       4
     );
+
     detectionResults.forEach((detection) => {
       if (detection.bbox) {
         const [x, y, w, h] = detection.bbox;
@@ -93,12 +161,22 @@ function drawStep1(
       }
     });
 
+    if (LM_SHOW_STEP1) {
+      detectionResults.forEach((d) => {
+        if (!d.landmarks) return;
+        if (LM_MODE === "nose") {
+          drawNoseLandmarks(ctx, d.landmarks, canvasWidth, canvasHeight);
+        } else {
+          // drawLandmarks(ctx, d.landmarks as any, LM_RADIUS, LM_COLOR);
+        }
+      });
+    }
+
     if (validation.message) {
       banner(ctx, validation.message, 80);
     }
   }
 
-  // PIP sharpen
   if (CONFIG.SHARPEN.ENABLED) {
     const pipW = 160,
       pipH = 120;
@@ -110,42 +188,57 @@ function drawStep1(
   }
 }
 
+/* ====== Step 2 UI: แสดง overlay/ดีบัก (การเปลี่ยนเฟสทำใน useFaceMesh แล้ว) ====== */
 function drawStep2(
   ctx: CanvasRenderingContext2D,
-  detection: DetectionResult,
-  state: FaceScanState
+  detection: DetectionResult | undefined,
+  state: FaceScanState,
+  canvasWidth: number,
+  canvasHeight: number
 ) {
-  if (!detection.landmarks || state.phase === "-") return;
+  if (!detection?.landmarks || state.phase === "-") return;
 
-  // จุด landmark ปิดไว้
-  if (SHOW_OVERLAY) {
-    if (CONFIG.LANDMARKS.SHOW_IN_STEP2) {
-      drawLandmarks(ctx, detection.landmarks, 1, "white");
+  if (SHOW_OVERLAY && LM_SHOW_STEP2) {
+    if (LM_MODE === "nose") {
+      drawNoseLandmarks(ctx, detection.landmarks, canvasWidth, canvasHeight);
+    } else {
+      drawLandmarks(ctx, detection.landmarks as any, LM_RADIUS, LM_COLOR);
     }
+  }
 
-    // ปิดbanner
-    const instruction = Step2Validator.getPhaseInstruction(state.phase as any);
-    banner(ctx, instruction, 120);
+  const instruction = Step2Validator.getPhaseInstruction(state.phase as any);
+  banner(ctx, instruction, 120);
 
-    // ปิด Progress text
-    if (detection.yawDeg !== null || detection.pitchDeg !== null) {
-      const progress = Step2Validator.getPhaseProgress(
-        state.phase as any,
-        detection.yawDeg,
-        detection.pitchDeg
-      );
-      if (progress) {
-        ctx.save();
-        ctx.fillStyle = "white";
-        ctx.font = "16px system-ui";
-        ctx.fillText(progress, 10, 74);
-        ctx.restore();
-      }
+  // แสดง metric พื้นฐานเพื่อดีบัก
+  const noseIdx = 1;
+  const lm = detection.landmarks as LM[];
+  const nose = lm?.[noseIdx];
+  if (nose) {
+    let xPx = nose.x * canvasWidth;
+    const yPx = nose.y * canvasHeight;
+    if (CONFIG.CAMERA.MIRRORED_INPUT) xPx = canvasWidth - xPx;
+    const cx = canvasWidth / 2;
+    const cy = canvasHeight / 2;
+    const dx = xPx - cx;
+    const dy = yPx - cy;
+
+    ctx.save();
+    if (SHOW_OVERLAY) {
+      ctx.fillStyle = "white";
+      ctx.font = "16px system-ui";
+      const lines = [
+        `phase: ${state.phase}`,
+        `dx: ${dx.toFixed(1)} px, dy: ${dy.toFixed(1)} px`,
+      ];
+      lines.forEach((t, i) => ctx.fillText(t, 10, 56 + i * 18));
     }
+    ctx.restore();
 
-    // ข้อความเฉพาะ phase ปาก
-    if (state.phase === "mouth" && detection.marValue !== null) {
-      banner(ctx, "Now, please close your mouth", 150);
-    }
+    // กรอบสีบอกสถานะคร่าว ๆ (เฉพาะแสดงผล)
+    alertFrame(ctx, "rgba(255,255,255,0.6)", 4);
+  }
+
+  if (state.phase === "mouth" && detection.marValue !== null) {
+    banner(ctx, "Now, please close your mouth", 150);
   }
 }

--- a/src/features/scan-face/configs/constant.ts
+++ b/src/features/scan-face/configs/constant.ts
@@ -9,63 +9,94 @@ export const CONFIG = {
     WIDTH: 1280,
     HEIGHT: 720,
   },
+
+  UI: {
+    DRAW_CROSSHAIR: true,
+    // ถ้าอยากเลื่อนบวกลง ให้เปลี่ยนค่านี้แทนการฮาร์ดโค้ดในไฟล์วาด
+    CROSSHAIR_OFFSET_Y_FRAC: 0.0, // 0 = จุดศูนย์กลางจริง ตรงกับฝั่งคำนวณ
+  },
+
   SHARPEN: {
     ENABLED: true,
     KERNEL: SHARPEN_KERNEL,
   },
+
   FACE_SIZE: {
     FAR_THRESHOLD: 180,
     NEAR_THRESHOLD: 320,
   },
+
   BRIGHTNESS: {
     DARK_THRESHOLD: 60,
     BRIGHT_THRESHOLD: 190,
   },
+
   POSITION: {
-    CENTER_TOLERANCE: 0.15,
+    CENTER_TOLERANCE: 0.12, // กระชับขึ้นนิด ให้ยืนกลางจอมากขึ้น
   },
+
   TIMING: {
     STEP1_HOLD_SECONDS: 2.0,
-    // ลด hold time เพื่อให้รวดเร็วกว่า
-    STEP2_YAW_HOLD_SECONDS: 0.8, // ลดจาก 1.2
-    STEP2_PITCH_HOLD_SECONDS: 0.6, // ลดจาก 1.0
 
-    // เพิ่ม progressive timing
-    EASY_HOLD_SECONDS: 0.5, // สำหรับผู้ใช้ใหม่
+    // ถือท่าหันซ้าย/ขวา/พยักขึ้น/ลง ให้นิ่งพอประมาณ แต่ยังเร็ว
+    STEP2_YAW_HOLD_SECONDS: 0.8,
+    STEP2_PITCH_HOLD_SECONDS: 0.6,
 
-    BLINK_MIN_SECONDS: 0.3,
+    EASY_HOLD_SECONDS: 0.5,
+
+    BLINK_MIN_SECONDS: 0.28, // 0.25–0.30 กำลังดี
     MOUTH_OPEN_MIN_SECONDS: 0.6,
     MOUTH_OPEN_MAX_SECONDS: 2.0,
     MOUTH_CLOSE_MIN_SECONDS: 0.6,
   },
+
   SMOOTHING: {
     BOX_EMA_ALPHA: 0.3,
-    // ลด EMA alpha เพื่อให้ responsive กว่า
-    YAW_EMA_ALPHA: 0.25, // เพิ่มจาก 0.15
-    PITCH_EMA_ALPHA: 0.25, // เพิ่มจาก 0.15
 
-    // เพิ่มค่าใหม่สำหรับ zero position
-    ZERO_EMA_ALPHA: 0.05, // ใช้สำหรับ baseline ให้ stable กว่า
+    // ทำให้การอ่านมุมนิ่งแต่ยังตามทัน — 0.20–0.30
+    YAW_EMA_ALPHA: 0.25,
+    PITCH_EMA_ALPHA: 0.25,
+
+    // baseline ศูนย์กลาง ให้นิ่งมาก ๆ
+    ZERO_EMA_ALPHA: 0.05,
 
     BLINK_BASE_EMA_ALPHA: 0.1,
     MOUTH_BASE_EMA_ALPHA: 0.1,
+
+    // ✅ ใช้ใน StepProcessor.isYawMoving()/isPitchMoving()
+    YAW_MOMENTUM_MIN: 4.0,
+    PITCH_MOMENTUM_MIN: 3.5,
   },
+
   THRESHOLDS: {
-    // ลดค่า threshold ให้อ่อนโยนกว่าเดิม
-    YAW_ENTER_DEG: 6.0, // ลดจาก 8.0
-    YAW_EXIT_DEG: 3.0, // ลดจาก 5.0
-    YAW_ZERO_UPDATE_BAND: 15.0, // เพิ่มจาก 8.0 เพื่อให้ stable กว่า
-    PITCH_ENTER_DEG: 4.5, // ลดจาก 6.0
-    PITCH_EXIT_DEG: 2.0, // ลดจาก 3.0
-    PITCH_ZERO_UPDATE_BAND: 8.0, // เพิ่มจาก 4.0
+    // เข้าง่ายกว่าเดิมเล็กน้อย แต่มี hysteresis กันสั่น
+    YAW_ENTER_DEG: 6.0,
+    YAW_EXIT_DEG: 3.0,
+    YAW_ZERO_UPDATE_BAND: 15.0,
+
+    PITCH_ENTER_DEG: 4.5,
+    PITCH_EXIT_DEG: 2.0,
+    PITCH_ZERO_UPDATE_BAND: 8.0,
 
     BLINK_THRESH_FRACTION: 0.72,
     MOUTH_OPEN_DELTA: 0.12,
+
+    // ✅ ใช้ใน brightnessOK()
+    BRIGHTNESS_MIN: 70,
+    BRIGHTNESS_MAX: 210,
   },
+
   CAMERA: {
     MIRRORED_INPUT: true,
+    // ✅ แก้เคสหันซ้ายแต่ pass ขวา: -1 กลับทิศ yaw ให้ตรงภาพ selfie
+    YAW_SIGN: -1,
   },
+
   LANDMARKS: {
+    MODE: "all", // "nose" | "all"
+    SHOW_IN_STEP1: true,
     SHOW_IN_STEP2: true,
+    COLOR: "#22c55e",
+    RADIUS: 1.5,
   },
 } as const;

--- a/src/features/scan-face/hooks/useFaceMesh.ts
+++ b/src/features/scan-face/hooks/useFaceMesh.ts
@@ -1,3 +1,4 @@
+// hooks/useFaceMesh.ts
 import { useEffect, useRef, useState, useCallback } from "react";
 import type { LM, FaceScanState, DetectionResult } from "../configs/type";
 import { CONFIG } from "../configs/constant";
@@ -17,6 +18,12 @@ import {
   groupOfPhase,
 } from "../utils/movements";
 import { captureStore } from "../state/captureStore";
+
+// ✅ นำเข้า tracker และ type
+import {
+  HeadMotionTracker,
+  type HeadPhase,
+} from "../utils/motion/HeadMotionTracker";
 
 /* ===== Android detect ===== */
 const isAndroid =
@@ -76,7 +83,7 @@ export function useFaceMesh(
 
   /* ===== throttle UI updates ===== */
   const lastUIAtRef = useRef(0);
-  const UI_INTERVAL_MS = 150; // ~6-7fps สำหรับ UI ก็พอ
+  const UI_INTERVAL_MS = 150;
   function setUIThrottled(patch: Partial<FaceScanState>) {
     const now = performance.now();
     if (now - lastUIAtRef.current > UI_INTERVAL_MS) {
@@ -100,7 +107,6 @@ export function useFaceMesh(
   const detectionResultRef = useRef<DetectionResult>(INITIAL_DET);
   const lastDetUIRef = useRef(0);
   function updateDetectionResultUI(det: DetectionResult) {
-    // อัปเดตลง state เท่าที่จำเป็น เพื่อลด re-render
     const now = performance.now();
     const criticalChange =
       (detectionResultRef.current.bbox == null && det.bbox != null) ||
@@ -193,6 +199,61 @@ export function useFaceMesh(
     return prev === 0 ? next : alpha * next + (1 - alpha) * prev;
   }
 
+  /** หาพิกัดปลายจมูก (px) โดยอิงการ mirror ให้ตรงกับที่ผู้ใช้เห็น */
+  function getNosePxFromDet(
+    det: DetectionResult,
+    canvasW: number,
+    canvasH: number,
+    mirrored: boolean
+  ): { x: number; y: number } | null {
+    const noseIdx = 1; // Mediapipe FaceMesh nose tip
+    const lm = det.landmarks as LM[] | null;
+    if (!lm || !lm[noseIdx]) return null;
+    const nx = lm[noseIdx].x * canvasW;
+    const ny = lm[noseIdx].y * canvasH;
+    return {
+      x: mirrored ? canvasW - nx : nx,
+      y: ny,
+    };
+  }
+
+  // ✅ Tracker (ย้ายมาใช้ใน pipeline หลัก)
+  const trackerRef = useRef<HeadMotionTracker | null>(null);
+  const passCooldownRef = useRef(0);
+  const PASS_COOLDOWN_MS = 800;
+
+  useEffect(() => {
+    trackerRef.current = new HeadMotionTracker({
+      emaAlphaPos: 0.25,
+      emaAlphaVel: 0.2,
+      targetEnter: 0.06,
+      targetExit: 0.04,
+      minHoldMs: 450,
+      dirTol: 0.02,
+      swapYawLR: false, // ตั้งตามที่ใช้อยู่
+    });
+    return () => {
+      trackerRef.current = null;
+    };
+  }, []);
+
+  function gotoNextAllowedPhase() {
+    const allowed = allowedPhasesRef.current;
+    if (!allowed || allowed.length === 0) return;
+
+    const cur = managers.current.state.subPhase as Phase;
+    const idx = allowed.indexOf(cur);
+    if (idx === -1) {
+      managers.current.state.subPhase = allowed[0];
+      return;
+    }
+    if (idx < allowed.length - 1) {
+      managers.current.state.subPhase = allowed[idx + 1];
+    } else {
+      // อยู่ท้ายรายการแล้ว → ปล่อยให้ logic ด้านล่างจัดการ complete กลุ่ม
+    }
+  }
+
   const processDetectionResults = useCallback(
     (results: any) => {
       if (!mountedRef.current) return;
@@ -208,13 +269,13 @@ export function useFaceMesh(
       if (fps !== null) {
         const now = performance.now();
         fpsEmaRef.current = ema(fps, fpsEmaRef.current);
+        (window as any).__fpsEma = fpsEmaRef.current;
 
         if (now - lastFpsUIRef.current > 500) {
           setUIThrottled({ fps: Math.round(fpsEmaRef.current) });
           lastFpsUIRef.current = now;
         }
 
-        // Auto quality control
         if (fpsEmaRef.current < 14) {
           faceMeshRef.current?.setOptions({
             refineLandmarks: false,
@@ -239,14 +300,13 @@ export function useFaceMesh(
           ? managers.current.detector.processLandmarks(faceLms, canvas)
           : [];
 
-      // เก็บตัวแรกไว้ใน state เพื่อใช้แสดงผล/เช็ค bbox
       const firstDet: DetectionResult = dets[0] ?? { ...INITIAL_DET };
       if (dets.length === 0) {
         managers.current.ema.boxEma.reset();
       }
       updateDetectionResultUI(firstDet);
 
-      // === Step process (คาดหวัง array) ===
+      // === Step process ===
       const { currentStep } = managers.current.state;
       if (currentStep === 1) {
         managers.current.stepProcessor.processStep1(
@@ -255,7 +315,46 @@ export function useFaceMesh(
           canvas.height
         );
       } else if (currentStep === 2) {
+        // เดิมยังใช้ StepProcessor เพื่อ logic อื่น ๆ ของ Step2
         managers.current.stepProcessor.processStep2(firstDet);
+
+        // ✅ ใหม่: ใช้ HeadMotionTracker ตัดสิน pass และสั่งเปลี่ยนเฟส
+        const subPhase = managers.current.state.subPhase as HeadPhase;
+        if (subPhase && firstDet.landmarks) {
+          const nose = getNosePxFromDet(
+            firstDet,
+            canvas.width,
+            canvas.height,
+            CONFIG.CAMERA.MIRRORED_INPUT
+          );
+          if (nose) {
+            const cx = canvas.width / 2;
+            const cy = canvas.height / 2;
+            const dx = nose.x - cx;
+            const dy = nose.y - cy;
+
+            const tracker = trackerRef.current;
+            if (tracker) {
+              const out = tracker.update({
+                dx,
+                dy,
+                canvasW: canvas.width,
+                canvasH: canvas.height,
+                phase: subPhase,
+                now: performance.now(),
+              });
+
+              const now = performance.now();
+              if (
+                out.pass &&
+                now - passCooldownRef.current > PASS_COOLDOWN_MS
+              ) {
+                passCooldownRef.current = now;
+                gotoNextAllowedPhase();
+              }
+            }
+          }
+        }
       }
 
       // ==== เปลี่ยนขั้น / สุ่ม movement / เริ่มจับเวลา ====
@@ -268,7 +367,6 @@ export function useFaceMesh(
           stepStartAtRef.current = null;
         }
 
-        // เปิด refine เฉพาะตอน Step 2
         if (stepNow === 2) {
           faceMeshRef.current?.setOptions({ refineLandmarks: true });
 
@@ -290,12 +388,11 @@ export function useFaceMesh(
           }
           lastCapAtRef.current = {};
         } else {
-          // นอก Step 2 ลดงานละเอียด
           faceMeshRef.current?.setOptions({ refineLandmarks: false });
         }
       }
 
-      // Timeout ต่อขั้น (เฉพาะ Step 1/2)
+      // Timeout ต่อขั้น
       if ((stepNow === 1 || stepNow === 2) && stepStartAtRef.current != null) {
         const elapsed = performance.now() - stepStartAtRef.current;
         if (elapsed >= STEP_TIMEOUT_MS) {
@@ -305,14 +402,13 @@ export function useFaceMesh(
       }
 
       // ===== Capture (ทั้งจอ) =====
-      // จบ Step1 → แคปหนึ่งรูป (ไม่ block main thread)
       if (stepNow >= 2 && captureStore.get().step1Sample == null) {
         captureToBlobURL(video, { quality: 0.75 }).then((url) => {
           if (url) captureStore.setStep1Sample(url);
         });
       }
 
-      // Step2 → แคปเฉพาะกลุ่มที่ถูกสุ่ม (ใช้ firstDet ในการเช็ค bbox)
+      // Step2 → แคปเฉพาะกลุ่มที่ถูกสุ่ม
       if (stepNow === 2 && firstDet.bbox && selectedGroupsRef.current) {
         const phaseNow = managers.current.state.subPhase as Phase;
         const grp = groupOfPhase(phaseNow);
@@ -414,7 +510,7 @@ export function useFaceMesh(
     }
   }, []);
 
-  // Setup camera + FaceMesh (ลดงานฝั่ง Android: ความละเอียด/เฟรมเรต)
+  // Setup camera + FaceMesh
   const setupCamera = useCallback(async () => {
     if (!videoRef.current || !canvasRef.current) return;
     const mySessionId = ++sessionIdRef.current;
@@ -431,7 +527,6 @@ export function useFaceMesh(
       });
       faceMeshRef.current = faceMesh;
 
-      // เริ่มด้วย refineLandmarks: false เพื่อลดภาระ
       faceMesh.setOptions({
         maxNumFaces: 1,
         refineLandmarks: false,
@@ -448,19 +543,6 @@ export function useFaceMesh(
 
       const targetW = isAndroid ? 640 : 1280;
       const targetH = Math.round((targetW * 9) / 16);
-      const targetFps = isAndroid ? 30 : 60;
-
-      const constraints: MediaStreamConstraints = {
-        video: {
-          facingMode: "user",
-          width: { ideal: targetW, max: targetW },
-          height: { ideal: targetH, max: targetH },
-          frameRate: { ideal: targetFps, max: targetFps },
-        },
-        audio: false,
-      };
-
-      await navigator.mediaDevices.getUserMedia(constraints);
 
       const cam = new Camera(videoRef.current!, {
         onFrame: async () => {
@@ -560,6 +642,8 @@ export function useFaceMesh(
   const resetStep2 = useCallback(() => {
     managers.current.state.reset();
     managers.current.ema.reset();
+    trackerRef.current?.reset();
+    passCooldownRef.current = 0;
   }, []);
 
   return {

--- a/src/features/scan-face/utils/faceMesh/DetectionProcessor.ts
+++ b/src/features/scan-face/utils/faceMesh/DetectionProcessor.ts
@@ -5,6 +5,14 @@ import { FaceDetector, EyeDetector, MouthDetector } from "../detectors";
 import { FaceMeshState } from "./FaceMeshState";
 import { EMAManager } from "./EMAManager";
 
+/**
+ * DetectionProcessor
+ * - คำนวณ bbox, ความสว่าง
+ * - วัดออฟเซ็ต "ปลายจมูก" เทียบกับเครื่องหมายบวกกลางจอ (signed offset)
+ *   * yawDeg  = ออฟเซ็ตแกน X แบบ normalized (ซ้าย = ลบ, ขวา = บวก) หลัง apply MIRRORED_INPUT
+ *   * pitchDeg= ออฟเซ็ตแกน Y แบบ normalized (ขึ้น = ลบ, ลง = บวก)
+ * - ทำ zero-tracking + EMA (ยังคงไว้ ถ้าต้องการความนิ่ง)
+ */
 export class DetectionProcessor {
   constructor(
     private state: FaceMeshState,
@@ -15,7 +23,6 @@ export class DetectionProcessor {
   calculateFPS(): number | null {
     const now = performance.now();
     this.state.frameCount++;
-
     if (now - this.state.lastFpsTime >= 1000) {
       const fps = Math.round(
         (this.state.frameCount * 1000) / (now - this.state.lastFpsTime)
@@ -34,6 +41,7 @@ export class DetectionProcessor {
     const ctx = canvas.getContext("2d")!;
 
     return faces.map((landmarks) => {
+      // 1) BBox + Brightness (ใช้ FaceDetector เดิม + EMA กล่อง)
       const bbox = FaceDetector.getBoundingBox(
         landmarks,
         canvas.width,
@@ -42,20 +50,30 @@ export class DetectionProcessor {
       const smoothedBox = this.ema.boxEma.update(bbox);
       const brightness = FaceDetector.calculateBrightness(ctx, smoothedBox);
 
-      const { yawDeg: rawYaw, pitchDeg: rawPitch } =
-        FaceDetector.estimateYawPitch(landmarks, canvas.width, canvas.height);
-      this.updatePoseZeros(rawYaw, rawPitch);
+      // 2) วัดออฟเซ็ตปลายจมูกเทียบ "จุดบวกกลางจอ"
+      const { yawNorm, pitchNorm } = signedNoseOffsets(
+        landmarks,
+        canvas.width,
+        canvas.height,
+        CONFIG.CAMERA.MIRRORED_INPUT
+      );
 
-      const yawAdj = rawYaw - (this.ema.yawZero.value ?? 0);
-const pitchAdj = rawPitch - (this.ema.pitchZero.value ?? 0);
-const yawDeg = this.ema.yawEma.update(yawAdj);
-const pitchDeg = this.ema.pitchEma.update(pitchAdj);
-// อัปเดต EMA เร็ว/ช้า สำหรับ momentum
-this.ema.yawFast.update(yawAdj);
-this.ema.yawSlow.update(yawAdj);
-this.ema.pitchFast.update(pitchAdj);
-this.ema.pitchSlow.update(pitchAdj);
+      // 3) อัปเดต zero เฉพาะตอนอยู่ใกล้ศูนย์ (ยังคงกลไกเดิมไว้เพื่อความนิ่ง)
+      this.updatePoseZeros(yawNorm, pitchNorm);
 
+      // 4) หัก zero แล้วทำ EMA (ได้ค่า yawDeg/pitchDeg เป็นออฟเซ็ต normalized หลังปรับศูนย์)
+      const yawAdj = yawNorm - (this.ema.yawZero.value ?? 0);
+      const pitchAdj = pitchNorm - (this.ema.pitchZero.value ?? 0);
+
+      const yawDeg = this.ema.yawEma.update(yawAdj);
+      const pitchDeg = this.ema.pitchEma.update(pitchAdj);
+
+      this.ema.yawFast.update(yawAdj);
+      this.ema.yawSlow.update(yawAdj);
+      this.ema.pitchFast.update(pitchAdj);
+      this.ema.pitchSlow.update(pitchAdj);
+
+      // 5) EAR / MAR
       const earValue = EyeDetector.getEyeAspectRatio(
         landmarks,
         canvas.width,
@@ -71,6 +89,8 @@ this.ema.pitchSlow.update(pitchAdj);
         landmarks,
         bbox: smoothedBox,
         brightness,
+        // หมายเหตุ: ตอนนี้ field ชื่อ yawDeg/pitchDeg = "ระยะออฟเซ็ต normalized"
+        // (หน่วยเชิงสัดส่วนกับครึ่งจอ) ไม่ใช่องศาจริง เพื่อให้สอดคล้อง requirement
         yawDeg,
         pitchDeg,
         earValue,
@@ -79,21 +99,68 @@ this.ema.pitchSlow.update(pitchAdj);
     });
   }
 
+  /** อัปเดตค่าอ้างอิงศูนย์ (zero) เมื่อศีรษะอยู่ใกล้ตำแหน่งกลาง */
   private updatePoseZeros(rawYaw: number, rawPitch: number) {
     const { YAW_ZERO_UPDATE_BAND, PITCH_ZERO_UPDATE_BAND } = CONFIG.THRESHOLDS;
 
-    // อัพเดต zero position เฉพาะเมื่อหน้าอยู่ใกล้กลาง
     if (
-      !this.ema.yawZero.value ||
+      this.ema.yawZero.value == null ||
       Math.abs(rawYaw - this.ema.yawZero.value) <= YAW_ZERO_UPDATE_BAND
     ) {
       this.ema.yawZero.update(rawYaw);
     }
     if (
-      !this.ema.pitchZero.value ||
+      this.ema.pitchZero.value == null ||
       Math.abs(rawPitch - this.ema.pitchZero.value) <= PITCH_ZERO_UPDATE_BAND
     ) {
       this.ema.pitchZero.update(rawPitch);
     }
   }
+}
+
+/* ======================= Helpers ======================= */
+
+/** index หลักของปลายจมูก (MediaPipe FaceMesh) */
+const L = { noseTip: 1 } as const;
+
+/**
+ * คำนวณออฟเซ็ตแบบมีเครื่องหมายของ "ปลายจมูก" เทียบกับเครื่องหมายบวกกลางจอ
+ * - คืนค่าเป็น normalized โดยหารด้วย "ครึ่งหนึ่งของความกว้าง/สูงจอ"
+ * - แนวแกน:
+ *   * X (ซ้าย/ขวา): ซ้ายเป็นลบ, ขวาเป็นบวก (หลังพิจารณา MIRRORED_INPUT แล้ว)
+ *   * Y (ขึ้น/ลง): ขึ้นเป็นลบ, ลงเป็นบวก (คุมให้เข้ากับ intuition ของผู้ใช้)
+ */
+function signedNoseOffsets(
+  landmarks: LM[],
+  canvasW: number,
+  canvasH: number,
+  mirrored: boolean
+) {
+  const nose = landmarks[L.noseTip];
+  if (!nose) return { yawNorm: 0, pitchNorm: 0 };
+
+  // พิกัดจอ (px)
+  let xPx = nose.x * canvasW;
+  const yPx = nose.y * canvasH;
+
+  // ถ้าวิดีโอถูก mirror ตอนแสดงผล ให้กลับแกน X ของจุดเพื่อความสอดคล้องกับภาพที่ผู้ใช้เห็น
+  if (mirrored) xPx = canvasW - xPx;
+
+  const cx = canvasW / 2;
+  const cy = canvasH / 2;
+
+  // ออฟเซ็ตเป็นสัดส่วนกับ "ครึ่งจอ" → ขอบซ้าย = -1, ขอบขวา = +1
+  const yawNorm = (xPx - cx) / (canvasW / 2); // ซ้ายลบ/ขวาบวก
+  const pitchNorm = (yPx - cy) / (canvasH / 2); // ขึ้นลบ/ลงบวก (เพราะ y ลงล่าง)
+
+  // clamp กันค่าเผื่อเลยขอบ
+  return {
+    yawNorm: clampFinite(yawNorm, -1, 1),
+    pitchNorm: clampFinite(pitchNorm, -1, 1),
+  };
+}
+
+function clampFinite(v: number, lo: number, hi: number) {
+  if (!Number.isFinite(v)) return 0;
+  return Math.max(lo, Math.min(hi, v));
 }

--- a/src/features/scan-face/utils/faceMesh/StepProcessor.ts
+++ b/src/features/scan-face/utils/faceMesh/StepProcessor.ts
@@ -4,11 +4,10 @@ import { Step1Validator, Step2Validator } from "../validators";
 import { FaceMeshState } from "./FaceMeshState";
 import { EMAManager } from "./EMAManager";
 
+const USE_TRACKER_FOR_HEAD = true;
+
 export class StepProcessor {
-  constructor(
-    private state: FaceMeshState,
-    private ema: EMAManager
-  ) {}
+  constructor(private state: FaceMeshState, private ema: EMAManager) {}
 
   // runtime flags updated per frame in processStep2
   private _okLight: boolean = true;
@@ -107,10 +106,8 @@ export class StepProcessor {
     } else if (exitCondition?.()) {
       this.state.holdStart = null;
     }
-  
   }
 
-  
   private isYawMoving(): boolean {
     const yf = this.ema.yawFast.value ?? 0;
     const ys = this.ema.yawSlow.value ?? 0;
@@ -189,9 +186,7 @@ export class StepProcessor {
       this.state.subPhase = "mouth";
       this.state.blinkCloseStart = null;
     }
-
   }
-
 
   private handleMouth(marValue: number) {
     const baselineMAR = this.ema.marBase.value ?? marValue;

--- a/src/features/scan-face/utils/motion/HeadMotionTracker.ts
+++ b/src/features/scan-face/utils/motion/HeadMotionTracker.ts
@@ -1,0 +1,197 @@
+// utils/motion/HeadMotionTracker.ts
+//
+// ตรวจจับการหันศีรษะ (ซ้าย/ขวา/ขึ้น/ลง) ด้วย metric nose↔center + EMA + hysteresis + hold
+// รองรับ swapYawLR เพื่อสลับความหมายซ้าย/ขวาเมื่อจำเป็น
+
+export type HeadPhase =
+  | "yaw_left"
+  | "yaw_right"
+  | "pitch_up"
+  | "pitch_down"
+  | "-";
+
+export interface HeadMotionConfig {
+  emaAlphaPos?: number; // smoothing ตำแหน่ง (dx/dy)
+  emaAlphaVel?: number; // smoothing ความเร็ว
+  targetEnter?: number; // เกณฑ์เข้า (normalized ต่อ half-axis)
+  targetExit?: number; // เกณฑ์ออก (hysteresis) < targetEnter
+  minHoldMs?: number; // ต้องคงสภาพ >= minHoldMs ถึงจะ pass
+  dirTol?: number; // กันสั่นทิศทางรอบศูนย์ (normalized)
+  swapYawLR?: boolean; // true = สลับซ้าย/ขวา
+}
+
+export interface HeadMotionUpdate {
+  dx: number; // signed px: ซ้ายลบ/ขวาบวก (หลัง mirror แล้ว)
+  dy: number; // signed px: ขึ้นลบ/ลงบวก
+  canvasW: number;
+  canvasH: number;
+  phase: HeadPhase;
+  now: number; // performance.now()
+}
+
+export interface HeadMotionResult {
+  metricNorm: number; // ระยะ/half-axis (0..1)
+  metricPx: number; // ระยะพิกเซล
+  needed: "left" | "right" | "up" | "down" | "-";
+  dirNow: "left" | "right" | "up" | "down" | "center";
+  dirOK: boolean;
+  dxEma: number;
+  dyEma: number;
+  velNorm: number; // |velocity| normalized ต่อวินาที
+  enter: number;
+  exit: number;
+  heldMs: number;
+  pass: boolean;
+}
+
+export class HeadMotionTracker {
+  private cfg: Required<HeadMotionConfig>;
+  private prev: { t: number; dxEma: number; dyEma: number } | null = null;
+  private holdStart: number | null = null;
+  private lastPhase: HeadPhase = "-";
+
+  constructor(config?: HeadMotionConfig) {
+    this.cfg = {
+      emaAlphaPos: config?.emaAlphaPos ?? 0.25,
+      emaAlphaVel: config?.emaAlphaVel ?? 0.2,
+      targetEnter: config?.targetEnter ?? 0.06,
+      targetExit: config?.targetExit ?? 0.04,
+      minHoldMs: config?.minHoldMs ?? 450,
+      dirTol: config?.dirTol ?? 0.02,
+      swapYawLR: config?.swapYawLR ?? false,
+    };
+  }
+
+  reset() {
+    this.prev = null;
+    this.holdStart = null;
+    this.lastPhase = "-";
+  }
+
+  update(input: HeadMotionUpdate): HeadMotionResult {
+    const { dx, dy, canvasW, canvasH, phase, now } = input;
+
+    if (phase !== this.lastPhase) {
+      this.holdStart = null;
+      this.lastPhase = phase;
+    }
+
+    const halfW = canvasW / 2;
+    const halfH = canvasH / 2;
+
+    const dxEma = this.ema(this.prev?.dxEma ?? dx, dx, this.cfg.emaAlphaPos);
+    const dyEma = this.ema(this.prev?.dyEma ?? dy, dy, this.cfg.emaAlphaPos);
+
+    const dt = this.prev ? Math.max(1, now - this.prev.t) : 16.7;
+    const dtSec = dt / 1000;
+
+    let axis: "x" | "y" = "x";
+    let raw = 0;
+    let dirNeed: HeadMotionResult["needed"] = "-";
+    let dirNow: HeadMotionResult["dirNow"] = "center";
+    let metricPx = 0;
+    let metricNorm = 0;
+
+    const tolX = this.cfg.dirTol * halfW;
+    const tolY = this.cfg.dirTol * halfH;
+
+    switch (phase) {
+      case "yaw_left":
+      case "yaw_right": {
+        axis = "x";
+        raw = dxEma;
+        metricPx = Math.abs(dxEma);
+        metricNorm = Math.min(1, Math.abs(dxEma) / halfW);
+
+        const wantLeft = phase === "yaw_left";
+        const swapped = this.cfg.swapYawLR ? !wantLeft : wantLeft;
+
+        if (swapped) {
+          // ต้องการ "right" ถ้า phase=left และ "left" ถ้า phase=right
+          dirNeed = wantLeft ? "right" : "left";
+          dirNow = dxEma > tolX ? "right" : dxEma < -tolX ? "left" : "center";
+        } else {
+          dirNeed = wantLeft ? "left" : "right";
+          dirNow = dxEma < -tolX ? "left" : dxEma > tolX ? "right" : "center";
+        }
+        break;
+      }
+
+      case "pitch_up":
+      case "pitch_down": {
+        axis = "y";
+        raw = dyEma;
+        metricPx = Math.abs(dyEma);
+        metricNorm = Math.min(1, Math.abs(dyEma) / halfH);
+        const wantUp = phase === "pitch_up";
+        dirNeed = wantUp ? "up" : "down";
+        dirNow = dyEma < -tolY ? "up" : dyEma > tolY ? "down" : "center";
+        break;
+      }
+
+      default: {
+        axis = "x";
+        raw = 0;
+        metricPx = 0;
+        metricNorm = 0;
+        dirNeed = "-";
+        dirNow = "center";
+      }
+    }
+
+    const prevRaw = this.prev
+      ? axis === "x"
+        ? this.prev.dxEma
+        : this.prev.dyEma
+      : raw;
+    const denom = axis === "x" ? halfW : halfH;
+    const velInst = (raw - prevRaw) / denom / dtSec;
+    const velNorm = this.ema(0, Math.abs(velInst), this.cfg.emaAlphaVel);
+
+    const enter = this.cfg.targetEnter!;
+    const exit = this.cfg.targetExit!;
+    const dirOK =
+      (dirNeed === "left" && dirNow === "left") ||
+      (dirNeed === "right" && dirNow === "right") ||
+      (dirNeed === "up" && dirNow === "up") ||
+      (dirNeed === "down" && dirNow === "down");
+
+    let heldMs = 0;
+    let pass = false;
+
+    if (dirOK && metricNorm >= enter) {
+      if (this.holdStart == null) this.holdStart = now;
+      heldMs = now - (this.holdStart ?? now);
+      pass = heldMs >= this.cfg.minHoldMs!;
+    } else {
+      const stillInBand = dirOK && metricNorm >= exit;
+      if (!stillInBand) {
+        this.holdStart = null;
+        heldMs = 0;
+      } else {
+        heldMs = this.holdStart ? now - this.holdStart : 0;
+      }
+    }
+
+    this.prev = { t: now, dxEma, dyEma };
+
+    return {
+      metricNorm,
+      metricPx,
+      needed: dirNeed,
+      dirNow,
+      dirOK,
+      dxEma,
+      dyEma,
+      velNorm,
+      enter,
+      exit,
+      heldMs,
+      pass,
+    };
+  }
+
+  private ema(prev: number, next: number, alpha: number) {
+    return prev + alpha * (next - prev);
+  }
+}


### PR DESCRIPTION
…sync crosshair ref; tune thresholds & smoothing

สาเหตุ:
- พบอาการ “ยังหันซ้ายอยู่แต่ระบบนับ yaw_right ผ่าน” เนื่องจากสัญญาณทิศ yaw กลับด้าน
- UI crosshair ถูกเลื่อนลง 10% แต่ฝั่งคำนวณยังใช้จุดศูนย์กลางเดิม → ค่าพิทช์/ดีบักเพี้ยน
- มีตัวเปลี่ยนเฟสซ้ำซ้อน (StepProcessor + HeadMotionTracker) ทำให้เฟสอาจเด้งผิดจังหวะ
- ตัวโค้ดอ้าง config บางค่า (BRIGHTNESS_MIN/MAX, *MOMENTUM_MIN) แต่ยังไม่มีใน CONFIG

สิ่งที่เปลี่ยน:
- configs/constant.ts
  - เพิ่ม CAMERA.YAW_SIGN = -1 เพื่อ normalize สัญญาณ yaw ให้ตรงภาพ selfie
  - เพิ่ม UI.{DRAW_CROSSHAIR, CROSSHAIR_OFFSET_Y_FRAC} (ตั้งเป็น 0.0) เพื่อ sync จุดอ้างอิง UI/คำนวณ
  - เพิ่ม THRESHOLDS.{BRIGHTNESS_MIN:70, BRIGHTNESS_MAX:210}
  - เพิ่ม SMOOTHING.{YAW_MOMENTUM_MIN:4.0, PITCH_MOMENTUM_MIN:3.5}
  - ปรับค่า THRESHOLDS (YAW_ENTER/EXIT, PITCH_ENTER/EXIT) และ TIMING (blink ฯลฯ) ให้ “นุ่มมือแต่ไม่หลุด”
  - คง MIRRORED_INPUT = true
- utils/validators/Step2Validator.ts
  - เพิ่ม helper `yawN()` และบังคับใช้ทุกที่ที่อ่าน yawDeg (ซ้าย/ขวา) โดยอ้างอิง CAMERA.YAW_SIGN
  - คง pitch/blink/mouth logic เดิม แต่ได้ประโยชน์จากคอนฟิกใหม่
- hooks/useFaceMesh.ts
  - คำนวณ dx,dy เทียบกับศูนย์กลางที่ sync กับ `CONFIG.UI.CROSSHAIR_OFFSET_Y_FRAC`
  - ให้ HeadMotionTracker เป็น “authority” ในการผ่านเฟส yaw/pitch (เลิกซ้ำกับ StepProcessor)
  - ใช้ `gotoNextAllowedPhase()` เมื่อ tracker `pass` + ใส่ cooldown ป้องกันซ้อนเฟส
- utils/faceMesh/StepProcessor.ts
  - เมื่อ USE_TRACKER_FOR_HEAD เป็น true: ไม่เปลี่ยนเฟส yaw/pitch ใน StepProcessor; ปล่อยให้ดูแลเฉพาะ blink/mouth + baselines
  - `isYawMoving()/isPitchMoving()` อ้างอิง *MOMENTUM_MIN จาก CONFIG
- components/VideoCanvas.tsx
  - วาด crosshair แบบอิง `CONFIG.UI` (เลิกฮาร์ดโค้ดเลื่อนลง 10%)
  - SHOW_OVERLAY default เป็น false สำหรับ production-like

ผลลัพธ์:
- หันซ้ายแล้วจะไม่เกิด `yaw_right` pass อีก จนกว่าจะหันขวาจริงและถือครบ hold time
- พฤติกรรม yaw/pitch เสถียรขึ้นจาก hysteresis + single phase authority
- UI crosshair (ถ้าเปิด) ตรงกับจุดคำนวณ → dx/dy ไม่เพี้ยน
- โค้ดไม่อ้างคีย์ CONFIG ที่ไม่มีอีกต่อไป

การทดสอบ (QA checklist):
- [ ] หันซ้ายค้าง ≥0.8s → ผ่าน `yaw_left` เท่านั้น, ไม่เกิด `yaw_right` pass
- [ ] กลับมาศูนย์ แล้วหันขวาค้าง ≥0.8s → ผ่าน `yaw_right` ตามลำดับ
- [ ] พยักหน้าขึ้น/ลง ผ่านตาม `STEP2_PITCH_HOLD_SECONDS`
- [ ] กระพริบตา: EAR ต่ำกว่า baseline×0.72 ต่อเนื่อง ≥0.28s → ผ่าน
- [ ] อ้าปาก/ปิดปาก: MAR ≥ baseline+0.12 แล้วปิดค้าง ≥0.6s → ผ่าน
- [ ] Android low-FPS: ไม่มีอาการเด้งเฟสไวเกิน; ถ้าเสี่ยง ปรับ `STEP2_YAW_HOLD_SECONDS=1.0` ชั่วคราว
- [ ] เปิด/ปิด crosshair (`UI.DRAW_CROSSHAIR`) แล้วค่า dx/dy/phase ไม่เพี้ยน

เอกสาร/หมายเหตุ:
- หากพบว่าทิศซ้าย/ขวายังกลับด้าน ให้สลับ `CAMERA.YAW_SIGN` เป็น +1 (หรือทางเลือก: `swapYawLR` ใน HeadMotionTracker แต่ไม่ควรใช้สวนทางกัน)
- ถ้าต้องการเลื่อน crosshair ให้แก้เพียง `UI.CROSSHAIR_OFFSET_Y_FRAC` และให้ฝั่งคำนวณอ้างอิงค่าเดียวกันเสมอ